### PR TITLE
feat: add SMTP relay support without authentication (v0.0.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 **Author:** [abesticode](https://github.com/abesticode)  
-**Version:** 0.0.2  
+**Version:** 0.0.3  
 **Type:** Tool Plugin  
 **Repo:** https://github.com/abesticode/dify-plugin-email-html-pro
 
@@ -16,6 +16,7 @@ Email HTML Pro is a professional Dify plugin for sending HTML emails via SMTP wi
 ## Features
 
 - 📧 **SMTP Support**: Compatible with Gmail, AWS SES, and any standard SMTP server
+- 🔓 **SMTP Relay Support**: Works with unauthenticated relay servers (e.g., internal company relays)
 - 🎨 **Raw HTML Templates**: Send pre-built HTML templates without modification
 - 📝 **Markdown to HTML**: Automatically convert markdown content to beautiful HTML emails
 - 📎 **File Attachments**: Attach multiple files to your emails
@@ -39,10 +40,10 @@ Configure the following credentials in Dify:
 |-------|-------------|----------|
 | SMTP Server | Your SMTP server address (e.g., smtp.gmail.com) | ✅ |
 | SMTP Port | SMTP port (25, 465, or 587) | ✅ |
-| Email Account | Your email account for authentication | ✅ |
-| Email Password | Your email password or app password | ✅ |
+| Email Account | Your email account for SMTP authentication. Leave empty for relay servers without auth. | ❌ |
+| Email Password | Your email password or app password. Leave empty for relay servers without auth. | ❌ |
 | Encryption Method | NONE, SSL, or TLS | ✅ |
-| Sender Address | Custom sender address (optional, for AWS SES) | ❌ |
+| Sender Address | Custom sender address. **Required** when Email Account is not provided. | ❌ |
 
 ### Common SMTP Configurations
 
@@ -57,6 +58,15 @@ Configure the following credentials in Dify:
 - Port: `587`
 - Encryption: `TLS`
 - Note: Use IAM SMTP credentials
+
+**SMTP Relay (No Authentication):**
+- Server: Your relay server address (e.g., `relay.company.co.id`)
+- Port: `25`
+- Encryption: `NONE`
+- Email Account: _(leave empty)_
+- Email Password: _(leave empty)_
+- Sender Address: `no-reply@company.co.id` **(required)**
+- Note: Common for internal company relay servers
 
 ## Tools
 
@@ -164,6 +174,12 @@ MIT License
 - Send Email and Send Batch Email tools
 - Raw HTML and Markdown to HTML support
 - File attachments, CC/BCC support
+
+### v0.0.3
+- Added support for SMTP relay servers without authentication
+- Email Account and Email Password are now optional credentials
+- Sender Address is required when Email Account is not provided
+- Provider validation uses connection test (EHLO) for relay servers instead of sending test email
 
 ### v0.0.2
 - Added animated SVG icon with floating envelope and typing HTML brackets effect

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.2
+version: 0.0.3
 type: plugin
 author: abesticode
 name: email_html_pro
@@ -25,7 +25,7 @@ plugins:
   tools:
     - provider/email-html-pro.yaml
 meta:
-  version: 0.0.2
+  version: 0.0.3
   arch:
     - amd64
     - arm64

--- a/provider/email-html-pro.py
+++ b/provider/email-html-pro.py
@@ -1,3 +1,5 @@
+import smtplib
+import ssl
 from typing import Any
 
 from dify_plugin import ToolProvider
@@ -9,14 +11,14 @@ class DifyPluginEmailHtmlProProvider(ToolProvider):
     def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         try:
             # Validate required credentials are present
-            required_fields = ["smtp_server", "smtp_port", "email_account", "email_password", "encrypt_method"]
+            required_fields = ["smtp_server", "smtp_port", "encrypt_method"]
             for field in required_fields:
                 if not credentials.get(field):
                     raise ToolProviderCredentialValidationError(f"{field} is required")
             
             # Validate smtp_port is a valid integer
             try:
-                int(credentials.get("smtp_port", ""))
+                smtp_port = int(credentials.get("smtp_port", ""))
             except ValueError:
                 raise ToolProviderCredentialValidationError("smtp_port must be a valid integer")
             
@@ -25,15 +27,41 @@ class DifyPluginEmailHtmlProProvider(ToolProvider):
             if encrypt_method not in ["NONE", "SSL", "TLS"]:
                 raise ToolProviderCredentialValidationError("encrypt_method must be NONE, SSL, or TLS")
             
-            # Test the credentials by sending a test email to the sender
-            for _ in SendMailTool.from_credentials(credentials, user_id="").invoke(
-                tool_parameters={
-                    "subject": "Email HTML Pro - Setup Verification",
-                    "email_content": "Your Email HTML Pro plugin has been configured successfully!",
-                    "send_to": credentials.get("email_account")
-                }
-            ):
-                pass
+            email_account = credentials.get("email_account", "")
+            email_password = credentials.get("email_password", "")
+            sender_address = credentials.get("sender_address", "")
+            smtp_server = credentials.get("smtp_server", "")
+            
+            # If no email_account is provided, sender_address is required
+            if not email_account and not sender_address:
+                raise ToolProviderCredentialValidationError(
+                    "Sender Address is required when Email Account is not provided "
+                    "(e.g., for relay servers without authentication)"
+                )
+            
+            if email_account and email_password:
+                # Mode 1: With authentication - send a test email to verify credentials
+                send_to = sender_address or email_account
+                for _ in SendMailTool.from_credentials(credentials, user_id="").invoke(
+                    tool_parameters={
+                        "subject": "Email HTML Pro - Setup Verification",
+                        "email_content": "Your Email HTML Pro plugin has been configured successfully!",
+                        "send_to": send_to
+                    }
+                ):
+                    pass
+            else:
+                # Mode 2: Without authentication - test SMTP connection only
+                timeout = 30
+                ctx = ssl.create_default_context()
+                if encrypt_method == "SSL":
+                    with smtplib.SMTP_SSL(smtp_server, smtp_port, context=ctx, timeout=timeout) as server:
+                        server.ehlo()
+                else:
+                    with smtplib.SMTP(smtp_server, smtp_port, timeout=timeout) as server:
+                        if encrypt_method == "TLS":
+                            server.starttls(context=ctx)
+                        server.ehlo()
                 
         except ToolProviderCredentialValidationError:
             raise

--- a/provider/email-html-pro.yaml
+++ b/provider/email-html-pro.yaml
@@ -53,7 +53,7 @@ credentials_for_provider:
       ja_JP: SMTPサーバーポート（一般的なポートは25、465、587）
   email_account:
     type: text-input
-    required: true
+    required: false
     label:
       en_US: Email Account
       zh_Hans: 邮件账号
@@ -65,13 +65,13 @@ credentials_for_provider:
       pt_BR: your-email@example.com
       ja_JP: your-email@example.com
     help:
-      en_US: Email account used for SMTP authentication
-      zh_Hans: 用于SMTP认证的邮件账号
-      pt_BR: Conta de e-mail usada para autenticação SMTP
-      ja_JP: SMTP認証に使用するメールアカウント
+      en_US: Email account for SMTP authentication. Leave empty for relay servers that do not require authentication.
+      zh_Hans: 用于SMTP认证的邮件账号。对于不需要认证的中继服务器，请留空。
+      pt_BR: Conta de e-mail para autenticação SMTP. Deixe vazio para servidores de retransmissão que não requerem autenticação.
+      ja_JP: SMTP認証に使用するメールアカウント。認証不要のリレーサーバーの場合は空にしてください。
   email_password:
     type: secret-input
-    required: true
+    required: false
     label:
       en_US: Email Password
       zh_Hans: 邮件密码
@@ -83,10 +83,10 @@ credentials_for_provider:
       pt_BR: Digite sua senha de e-mail ou senha do aplicativo
       ja_JP: メールパスワードまたはアプリパスワードを入力してください
     help:
-      en_US: Email password or app-specific password for SMTP authentication
-      zh_Hans: 用于SMTP认证的邮件密码或应用专用密码
-      pt_BR: Senha de e-mail ou senha específica do aplicativo para autenticação SMTP
-      ja_JP: SMTP認証用のメールパスワードまたはアプリ固有のパスワード
+      en_US: Email password or app-specific password for SMTP authentication. Leave empty for relay servers that do not require authentication.
+      zh_Hans: 用于SMTP认证的邮件密码或应用专用密码。对于不需要认证的中继服务器，请留空。
+      pt_BR: Senha de e-mail ou senha específica do aplicativo para autenticação SMTP. Deixe vazio para servidores de retransmissão que não requerem autenticação.
+      ja_JP: SMTP認証用のメールパスワードまたはアプリ固有のパスワード。認証不要のリレーサーバーの場合は空にしてください。
   encrypt_method:
     type: select
     required: true
@@ -133,10 +133,10 @@ credentials_for_provider:
       pt_BR: sender@example.com
       ja_JP: sender@example.com
     help:
-      en_US: The designated sender address if different from email account. Required for AWS SES or custom sender addresses.
-      zh_Hans: 如果与邮件账号不同，指定的发件人地址。AWS SES或自定义发件人地址时需要。
-      pt_BR: O endereço do remetente designado se diferente da conta de e-mail. Necessário para AWS SES ou endereços de remetente personalizados.
-      ja_JP: メールアカウントと異なる場合の指定送信者アドレス。AWS SESやカスタム送信者アドレスに必要です。
+      en_US: The designated sender address if different from email account. Required when Email Account is not provided (e.g., relay servers without authentication).
+      zh_Hans: 如果与邮件账号不同，指定的发件人地址。当未提供邮件账号时必填（例如：不需要认证的中继服务器）。
+      pt_BR: O endereço do remetente designado se diferente da conta de e-mail. Obrigatório quando a Conta de E-mail não é fornecida (ex., servidores de retransmissão sem autenticação).
+      ja_JP: メールアカウントと異なる場合の指定送信者アドレス。メールアカウントが未入力の場合は必須です（例：認証不要のリレーサーバー）。
 tools:
   - tools/send_mail.yaml
   - tools/send_mail_batch.yaml

--- a/tools/send.py
+++ b/tools/send.py
@@ -14,8 +14,8 @@ class SendEmailToolParameters(BaseModel):
     smtp_server: str
     smtp_port: int
 
-    email_account: str
-    email_password: str
+    email_account: Optional[str] = None
+    email_password: Optional[str] = None
     sender_address: str
 
     sender_to: List[str]
@@ -98,13 +98,17 @@ def send_mail(params: SendEmailToolParameters) -> Dict[str, Tuple[int, bytes]]:
     try:
         if params.encrypt_method.upper() == "SSL":
             with smtplib.SMTP_SSL(params.smtp_server, params.smtp_port, context=ctx, timeout=timeout) as server:
-                server.login(params.email_account, params.email_password)
+                # Only login if credentials are provided
+                if params.email_account and params.email_password:
+                    server.login(params.email_account, params.email_password)
                 return server.sendmail(params.sender_address, all_recipients, msg.as_string())
         else:  # NONE or TLS
             with smtplib.SMTP(params.smtp_server, params.smtp_port, timeout=timeout) as server:
                 if params.encrypt_method.upper() == "TLS":
                     server.starttls(context=ctx)
-                server.login(params.email_account, params.email_password)
+                # Only login if credentials are provided
+                if params.email_account and params.email_password:
+                    server.login(params.email_account, params.email_password)
                 return server.sendmail(params.sender_address, all_recipients, msg.as_string())
     except Exception as e:
         logging.exception(f"Send email failed: {str(e)}")

--- a/tools/send_mail.py
+++ b/tools/send_mail.py
@@ -33,20 +33,21 @@ class SendMailTool(Tool):
             yield self.create_text_message("Invalid parameter smtp_port(should be int)")
             return
 
-            
-        if not sender:
-            yield self.create_text_message("please input email account (SMTP username)")
-            return
-        
         # Get sender address - this must be a valid email for the "From" header
         sender_address = self.runtime.credentials.get("sender_address", "") or sender
         
-        # Only validate sender_address if it's supposed to be an email
-        # For AWS SES and similar services, sender_address must be a verified email
-        if sender_address and not email_rgx.match(sender_address):
+        # sender_address is required (either from sender_address field or email_account)
+        if not sender_address:
             yield self.create_text_message(
-                f"Invalid sender address '{sender_address}'. The sender address must be a valid email format. "
-                f"For AWS SES, please set the 'Sender Address' field in credentials to your verified email."
+                "Sender Address is required when Email Account is not provided. "
+                "Please set the 'Sender Address' field in credentials."
+            )
+            return
+        
+        # Validate sender_address format
+        if not email_rgx.match(sender_address):
+            yield self.create_text_message(
+                f"Invalid sender address '{sender_address}'. The sender address must be a valid email format."
             )
             return
 

--- a/tools/send_mail_batch.py
+++ b/tools/send_mail_batch.py
@@ -33,20 +33,21 @@ class SendMailBatchTool(Tool):
             yield self.create_text_message("Invalid parameter smtp_port(should be int)")
             return
 
-            
-        if not sender:
-            yield self.create_text_message("please input email account (SMTP username)")
-            return
-        
         # Get sender address - this must be a valid email for the "From" header
         sender_address = self.runtime.credentials.get("sender_address", "") or sender
         
-        # Only validate sender_address if it's supposed to be an email
-        # For AWS SES and similar services, sender_address must be a verified email
-        if sender_address and not email_rgx.match(sender_address):
+        # sender_address is required (either from sender_address field or email_account)
+        if not sender_address:
             yield self.create_text_message(
-                f"Invalid sender address '{sender_address}'. The sender address must be a valid email format. "
-                f"For AWS SES, please set the 'Sender Address' field in credentials to your verified email."
+                "Sender Address is required when Email Account is not provided. "
+                "Please set the 'Sender Address' field in credentials."
+            )
+            return
+        
+        # Validate sender_address format
+        if not email_rgx.match(sender_address):
+            yield self.create_text_message(
+                f"Invalid sender address '{sender_address}'. The sender address must be a valid email format."
             )
             return
 


### PR DESCRIPTION
- Make email_account and email_password optional credentials
- Skip SMTP login when credentials are not provided
- Require sender_address when email_account is empty
- Provider validation uses EHLO connection test for relay servers
- Update README with relay server configuration example
- Bump version to 0.0.3